### PR TITLE
#26441 add event for updating translations, rename event for translations added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.7.0]
+### Added
+* plugin will now listen to event form other plugins for updating translations #26441
+
+### Chnaged
+* renamed event about newly added translations #26441
+
 ## [0.6.1]
 ### Fixed
 * list translations are saved with wrong field name #26686

--- a/Readme.md
+++ b/Readme.md
@@ -64,10 +64,12 @@ Now, let's consider that you are adding two languages: `Polish` and `English`, a
 }
 ```
 
-## Plugins interaction
+## Plugins events
 
-Multilingual Plugin sends information to other plugins when a new translation has been added.
-To use this information in your plugin, you need to listen to the event `flotiq-multilingual.translation::added`.
+### `flotiq-multilingual.translation::changed`
+
+Multilingual Plugin sends information to other plugins when a translation has been updated (or added).
+To use this information in your plugin, you need to listen to the event `flotiq-multilingual.translation::changed`.
 
 Event properties:
 
@@ -78,6 +80,22 @@ Event properties:
 | contentType    | Content type that includes the field                                                                |
 | initialData    | Initial data of the content object. This will be either an empty object or the object being edited. |
 | language       | Language in ISO 639 language code                                                                   |
+
+
+### `flotiq-multilingual.translation::update`
+
+Multilingual Plugin is listening to event from other plugins for updating translations.
+If you want Multilingual Plugin to create or update existing translation use `flotiq-multilingual.translation::update` event.
+
+Event properties:
+
+| Property       | Description                                                                                         |
+| -------------- | --------------------------------------------------------------------------------------------------- |
+| values         | Translated fields, eg. {"name": "New value"}                                                        |
+| language       | Language in ISO 639 language code                                                                   |
+| contentType    | Content type that includes the field                                                                |
+| initialData    | Initial data of the content object. This will be either an empty object or the object being edited. |
+| formUniqueKey  | Unique key from flotiq form events.                                                                 |
 
 ## Development
 

--- a/common/language.js
+++ b/common/language.js
@@ -1,2 +1,0 @@
-export const getLanguageKey = (contentType, contentObject, formUniqueKey) =>
-  `${contentType.name}-${contentObject?.id || "new"}-${formUniqueKey}`;

--- a/common/translations.js
+++ b/common/translations.js
@@ -1,0 +1,72 @@
+export const formLng = {};
+export const formikCache = {};
+
+export const getLanguageKey = (contentType, contentObject, formUniqueKey) =>
+  `${contentType.name}-${contentObject?.id || "new"}-${formUniqueKey}`;
+
+export const addToTranslations = (
+  contentType,
+  formik,
+  language,
+  initialData,
+  translations = {},
+) => {
+  const lngIndex = formik.values.__translations?.length || 0;
+  const order = contentType.metaDefinition.order.filter(
+    (key) => !["__translations", "__language"].includes(key),
+  );
+
+  const defaultObject = order.reduce((fields, currentFieldKey) => {
+    fields[currentFieldKey] = formik.values[currentFieldKey];
+    return fields;
+  }, {});
+
+  const newTranslation = {
+    ...defaultObject,
+    ...translations,
+    __language: language,
+  };
+
+  const fieldName = `__translations.[${lngIndex}]`;
+  formik.setFieldValue(fieldName, newTranslation);
+
+  window.FlotiqPlugins.run(`flotiq-multilingual.translation::changed`, {
+    fieldName,
+    newTranslation,
+    contentType,
+    initialData,
+    language,
+  });
+};
+
+export const updateTranlsations = (
+  language,
+  values,
+  contentType,
+  formik,
+  initialData,
+) => {
+  const languageIndex = (formik.values.__translations || []).findIndex(
+    ({ __language }) => __language === language,
+  );
+
+  if (languageIndex > -1) {
+    const newTranslation = {
+      ...formik.values.__translations[languageIndex],
+      ...values,
+    };
+
+    const fieldName = `__translations.[${languageIndex}]`;
+    formik.setFieldValue(fieldName, newTranslation);
+
+    window.FlotiqPlugins.run(`flotiq-multilingual.translation::changed`, {
+      fieldName,
+      newTranslation,
+      contentType,
+      initialData,
+      language,
+    });
+  } else {
+    addToTranslations(contentType, formik, language, initialData, values);
+  }
+};

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -2,7 +2,7 @@
   "id": "flotiq.multilingual",
   "name": "Multilingual plugin",
   "description": "Multilingual Plugin is an advanced plugin that allows easy addition and management of translations while editing objects. It supports multiple languages and enables users to define and manage their own language sets.",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-multilingual",
   "url": "https://localhost:3053/index.js",
   "permissions": [

--- a/plugins/form-add/index.js
+++ b/plugins/form-add/index.js
@@ -1,5 +1,5 @@
 import { allLngValue, lngDictionary } from "..";
-import { getLanguageKey } from "../../common/language";
+import { addToTranslations, formLng, getLanguageKey } from "../../common/translations";
 import {
   addElementToCache,
   getCachedElement,
@@ -8,42 +8,6 @@ import i18n from "../../i18n";
 import pluginInfo from "../../plugin-manifest.json";
 
 const selectedClass = "plugin-multilingual-tab__item--selected";
-
-export const formLng = {};
-
-const addToTranslations = (
-  contentType,
-  formik,
-  lngIndex,
-  lngKey,
-  initialData,
-) => {
-  const order = contentType.metaDefinition.order.filter(
-    (key) => !["__translations", "__language"].includes(key),
-  );
-
-  const defaultObject = order.reduce((fields, currentFieldKey) => {
-    fields[currentFieldKey] = formik.values[currentFieldKey];
-    return fields;
-  }, {});
-
-  const language = formLng[lngKey];
-  const newTranslation = {
-    ...defaultObject,
-    __language: language,
-  };
-  const fieldName = `__translations.[${lngIndex}]`;
-
-  formik.setFieldValue(fieldName, newTranslation);
-
-  window.FlotiqPlugins.run("flotiq-multilingual.translation::added", {
-    fieldName,
-    newTranslation,
-    contentType,
-    initialData,
-    language,
-  });
-};
 
 export const handleFormFieldAdd = (
   { contentType, formik, initialData, formUniqueKey },
@@ -125,8 +89,7 @@ export const handleFormFieldAdd = (
               addToTranslations(
                 contentType,
                 tabsData.formik,
-                tabsData.formik.values.__translations?.length || 0,
-                lngKey,
+                formLng[lngKey],
                 initialData,
               );
             }

--- a/plugins/form-config/co-form/index.js
+++ b/plugins/form-config/co-form/index.js
@@ -1,5 +1,4 @@
-import { getLanguageKey } from "../../../common/language";
-import { formLng } from "../../form-add";
+import { formikCache, formLng, getLanguageKey } from "../../../common/translations";
 
 const errorClass = "plugin-multilingual-tab__item--error";
 
@@ -28,6 +27,8 @@ export const handleCoFormConfig = async (
   if (!contentType?.metaDefinition?.propertiesConfig?.__translations) return;
 
   const lngKey = getLanguageKey(contentType, initialData, formUniqueKey);
+
+  formikCache[lngKey] = formik;
 
   config.key = `${formUniqueKey || "new"}-${formLng[lngKey]}-${name}`;
 

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -11,6 +11,11 @@ import i18n from "../i18n";
 import languages from "@cospired/i18n-iso-languages";
 import enLocaleLng from "@cospired/i18n-iso-languages/langs/en.json";
 import plLocaleLng from "@cospired/i18n-iso-languages/langs/pl.json";
+import {
+  formikCache,
+  getLanguageKey,
+  updateTranlsations,
+} from "../common/translations";
 
 languages.registerLocale(enLocaleLng);
 languages.registerLocale(plLocaleLng);
@@ -60,5 +65,19 @@ registerFn(pluginInfo, (handler, client, globals) => {
 
   handler.on("flotiq.plugin::removed", () =>
     handleRemovedEvent(client, globals),
+  );
+
+  handler.on(
+    "flotiq-multilingual.translation::update",
+    ({ contentType, initialData, formUniqueKey, language, values }) => {
+      const lngKey = getLanguageKey(contentType, initialData, formUniqueKey);
+      updateTranlsations(
+        language,
+        values,
+        contentType,
+        formikCache[lngKey],
+        initialData,
+      );
+    },
   );
 });


### PR DESCRIPTION
This PR is adding new event. Multilingual plugin will now listen to `flotiq-multilingual.translation::update` event for updating/creating new translations. 

Event `flotiq-multilingual.translation::added` is removed. In its place, `flotiq-multilingual.translation::changed` event is added which is emitted when new tranlsations are added or existing one is updated