### PR TITLE
drop uniqueness when copying fields to translation field description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.10.0]
+### Changed
+* now translation do not preserve unique settings #27394
+
 ## [0.9.3]
 ### Fixed
 * language tabs sticky positioning when there is flotiq information banner #27326

--- a/common/content-type-parser.js
+++ b/common/content-type-parser.js
@@ -80,6 +80,7 @@ const addTranslationsToContentType = async (contentType, defaultLanguage) => {
 
   const translationPropertiesConfig = order.reduce((config, key) => {
     config[key] = contentType.metaDefinition.propertiesConfig[key];
+    config[key].unique = false;
     return config;
   }, {});
 

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -2,7 +2,7 @@
   "id": "flotiq.multilingual",
   "name": "Multilingual plugin",
   "description": "Multilingual Plugin is an advanced plugin that allows easy addition and management of translations while editing objects. It supports multiple languages and enables users to define and manage their own language sets.",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-multilingual",
   "url": "https://localhost:3053/index.js",
   "permissions": [


### PR DESCRIPTION
Words in different languages can be spelt the same, so we need to make sure the fields in the translation list are not unique. 