### PR TITLE
#27794 fix infinite rerendering when changing content type in plugin settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.10.1]
+### Fixed
+* fix infinite rerendering when changing content type in plugin settings causing "Maximum call stack size exceeded" error #27794
+
 ## [0.10.0]
 ### Changed
 * now translation do not preserve unique settings #27394

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -2,7 +2,7 @@
   "id": "flotiq.multilingual",
   "name": "Multilingual plugin",
   "description": "Multilingual Plugin is an advanced plugin that allows easy addition and management of translations while editing objects. It supports multiple languages and enables users to define and manage their own language sets.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-multilingual",
   "url": "https://localhost:3053/index.js",
   "permissions": [

--- a/plugins/field-listeners/index.js
+++ b/plugins/field-listeners/index.js
@@ -17,7 +17,6 @@ export const handleFormFieldListenersAdd = ({ contentType, form, name }) => {
         onChange: ({ value }) => {
           let sliceIndex = null;
           const lastIndex = value.length - 1;
-
           if (lastIndex > 0) {
             if (value[0] === "--all--") {
               sliceIndex = 1;
@@ -26,10 +25,12 @@ export const handleFormFieldListenersAdd = ({ contentType, form, name }) => {
             }
           }
 
-          form.setFieldValue(
-            name,
-            sliceIndex ? value.slice(sliceIndex) : value,
-          );
+          if (sliceIndex !== null) {
+            form.setFieldValue(
+              name,
+              sliceIndex ? value.slice(sliceIndex) : value,
+            );
+          }
         },
       };
     } else if (name.startsWith("deepl_config")) {


### PR DESCRIPTION
When changing content type in plugin settings, the field listener was called on every change causing "Maximum call stack size exceeded" error and infinite rerenders of the form field